### PR TITLE
Pull request between base version and version with test enabled

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3726,11 +3726,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3743,15 +3745,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3854,7 +3859,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3864,6 +3870,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3876,17 +3883,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3903,6 +3913,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3975,7 +3986,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3985,6 +3997,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4090,6 +4103,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/frontend/src/app/about/about.component.spec.ts
+++ b/frontend/src/app/about/about.component.spec.ts
@@ -1,14 +1,18 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { MatIconModule } from '@angular/material/icon';
+import { TranslateService } from '../translate/translate.service';
 import { AboutComponent } from './about.component';
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
   let fixture: ComponentFixture<AboutComponent>;
+  
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AboutComponent ]
+      declarations: [ AboutComponent ],
+      imports : [ MatIconModule ],
+      providers : [ TranslateService]
     })
     .compileComponents();
   }));

--- a/frontend/src/app/about/about.component.spec.ts
+++ b/frontend/src/app/about/about.component.spec.ts
@@ -2,10 +2,11 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateService } from '../translate/translate.service';
 import { AboutComponent } from './about.component';
-import { MatMenuModule, MatToolbarModule, MatCardModule, MatGridListModule, MatTableModule, MatTabGroup, MatTab, MatTabHeader, MatTabBody } from '@angular/material';
+import { MatMenuModule, MatToolbarModule, MatCardModule, MatGridListModule, MatTableModule, MatTabGroup, MatTab, MatTabHeader, MatTabBody, MatNativeDateModule, MatDatepickerModule, MatSelectModule, MatInputModule, MatFormFieldModule, MatSnackBarModule, MatDialogModule, MatDividerModule, MatTabsModule } from '@angular/material';
 import { TranslatePipe } from '../translate/translate.pipe';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
  
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -21,13 +22,23 @@ describe('AboutComponent', () => {
         MatTabHeader,
         MatTabBody 
       ],
-      imports : [ MatIconModule,
+      imports : [
+        BrowserAnimationsModule,
+        MatIconModule,
         MatMenuModule,
         MatToolbarModule,
         MatCardModule,
         MatGridListModule,
         MatTableModule,
-        RouterTestingModule,
+        MatDividerModule,
+        MatDialogModule,
+        MatSnackBarModule,
+        MatFormFieldModule,
+        MatInputModule,
+        FormsModule,
+        MatSelectModule,
+        MatDatepickerModule,
+        MatNativeDateModule,
         CommonModule
       ],
       providers : [ TranslateService ]

--- a/frontend/src/app/about/about.component.spec.ts
+++ b/frontend/src/app/about/about.component.spec.ts
@@ -6,7 +6,7 @@ import { MatMenuModule, MatToolbarModule, MatCardModule, MatGridListModule, MatT
 import { TranslatePipe } from '../translate/translate.pipe';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CommonModule } from '@angular/common';
-
+ 
 describe('AboutComponent', () => {
   let component: AboutComponent;
   let fixture: ComponentFixture<AboutComponent>;

--- a/frontend/src/app/about/about.component.spec.ts
+++ b/frontend/src/app/about/about.component.spec.ts
@@ -2,6 +2,10 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateService } from '../translate/translate.service';
 import { AboutComponent } from './about.component';
+import { MatMenuModule, MatToolbarModule, MatCardModule, MatGridListModule, MatTableModule, MatTabGroup, MatTab, MatTabHeader, MatTabBody } from '@angular/material';
+import { TranslatePipe } from '../translate/translate.pipe';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -10,9 +14,23 @@ describe('AboutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AboutComponent ],
-      imports : [ MatIconModule ],
-      providers : [ TranslateService]
+      declarations: [ AboutComponent, 
+        TranslatePipe,
+        MatTabGroup,
+        MatTab,
+        MatTabHeader,
+        MatTabBody 
+      ],
+      imports : [ MatIconModule,
+        MatMenuModule,
+        MatToolbarModule,
+        MatCardModule,
+        MatGridListModule,
+        MatTableModule,
+        RouterTestingModule,
+        CommonModule
+      ],
+      providers : [ TranslateService ]
     })
     .compileComponents();
   }));

--- a/frontend/src/app/about/about.component.spec.ts
+++ b/frontend/src/app/about/about.component.spec.ts
@@ -2,11 +2,12 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateService } from '../translate/translate.service';
 import { AboutComponent } from './about.component';
-import { MatMenuModule, MatToolbarModule, MatCardModule, MatGridListModule, MatTableModule, MatTabGroup, MatTab, MatTabHeader, MatTabBody, MatNativeDateModule, MatDatepickerModule, MatSelectModule, MatInputModule, MatFormFieldModule, MatSnackBarModule, MatDialogModule, MatDividerModule, MatTabsModule } from '@angular/material';
+import { MatMenuModule, MatToolbarModule, MatCardModule, MatGridListModule, MatTableModule, MatTabGroup, MatTab, MatTabHeader, MatTabBody, MatNativeDateModule, MatDatepickerModule, MatSelectModule, MatInputModule, MatFormFieldModule, MatSnackBarModule, MatDialogModule, MatDividerModule, MatTabsModule, MatRippleModule } from '@angular/material';
 import { TranslatePipe } from '../translate/translate.pipe';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClient, HttpHandler } from '@angular/common/http';
  
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -16,32 +17,19 @@ describe('AboutComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ AboutComponent, 
-        TranslatePipe,
-        MatTabGroup,
-        MatTab,
-        MatTabHeader,
-        MatTabBody 
+        TranslatePipe 
       ],
       imports : [
-        BrowserAnimationsModule,
         MatIconModule,
         MatMenuModule,
         MatToolbarModule,
+        MatSelectModule,
         MatCardModule,
         MatGridListModule,
-        MatTableModule,
-        MatDividerModule,
-        MatDialogModule,
-        MatSnackBarModule,
-        MatFormFieldModule,
-        MatInputModule,
-        FormsModule,
-        MatSelectModule,
-        MatDatepickerModule,
-        MatNativeDateModule,
-        CommonModule
+        MatTabsModule,
+        BrowserAnimationsModule
       ],
-      providers : [ TranslateService ]
+      providers : [ TranslateService, HttpClient, HttpHandler ]
     })
     .compileComponents();
   }));

--- a/frontend/src/app/api/api.service.spec.ts
+++ b/frontend/src/app/api/api.service.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed, inject } from '@angular/core/testing';
 
 import { ApiService } from './api.service';
+import { HttpHandler, HttpClient } from '@angular/common/http';
 
 describe('ApiService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ApiService]
+      providers: [ApiService, HttpClient, HttpHandler]
     });
   });
 

--- a/frontend/src/app/api/api.service.ts
+++ b/frontend/src/app/api/api.service.ts
@@ -72,7 +72,7 @@ export class CSVData {
 })
 
 export class ApiService {
-  private apiUrl:string = "http://aquapp.utb.edu.co:8080/api/v1";
+  private apiUrl:string = "http://localhost:8080/api/v1";
 
   getNodes(): Observable<Node[]> {
     return this.http.get<Node[]>(this.apiUrl + "/nodes");

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -30,10 +30,5 @@ describe('AppComponent', () => {
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('AquApp');
   }));
-  it('should render title in a h1 tag', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to app!');
-  }));
+
 });

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,11 +1,23 @@
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { MatIconModule, MatMenuModule, MatToolbarModule, MatCardModule, MatGridListModule, MatTableModule } from '@angular/material';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
         AppComponent
       ],
+      imports : [ MatIconModule,
+        MatMenuModule,
+        MatToolbarModule,
+        MatCardModule,
+        MatGridListModule,
+        MatTableModule,
+        RouterTestingModule,
+        CommonModule
+      ]
     }).compileComponents();
   }));
   it('should create the app', async(() => {
@@ -16,7 +28,7 @@ describe('AppComponent', () => {
   it(`should have as title 'app'`, async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app');
+    expect(app.title).toEqual('AquApp');
   }));
   it('should render title in a h1 tag', async(() => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/frontend/src/app/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/dashboard/dashboard.component.spec.ts
@@ -1,6 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { DashboardComponent } from './dashboard.component';
+import { TranslatePipe } from '../translate/translate.pipe';
+import { MatTabsModule, MatIconModule } from '@angular/material';
+import { TranslateService } from '../translate/translate.service';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -8,7 +12,15 @@ describe('DashboardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DashboardComponent ]
+      declarations: [ DashboardComponent, TranslatePipe],
+      imports: [ MatTabsModule,
+        BrowserAnimationsModule,
+        MatIconModule
+      ],
+
+      providers:[
+        TranslateService
+      ]
     })
     .compileComponents();
   }));

--- a/frontend/src/app/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/dashboard/dashboard.component.spec.ts
@@ -1,9 +1,13 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DashboardComponent } from './dashboard.component';
 import { TranslatePipe } from '../translate/translate.pipe';
-import { MatTabsModule, MatIconModule } from '@angular/material';
+import { MatTabsModule, MatIconModule, MatMenuModule, MatToolbarModule, MatCardModule, MatGridListModule, MatTableModule, MatDividerModule, MatDialogModule, MatSnackBarModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatNativeDateModule, MatDatepickerModule } from '@angular/material';
 import { TranslateService } from '../translate/translate.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule } from '@angular/forms';
+import { HttpHandler, HttpClient } from '@angular/common/http';
+import { CommonModule } from '@angular/common';
+
 
 
 describe('DashboardComponent', () => {
@@ -15,11 +19,26 @@ describe('DashboardComponent', () => {
       declarations: [ DashboardComponent, TranslatePipe],
       imports: [ MatTabsModule,
         BrowserAnimationsModule,
-        MatIconModule
+        MatIconModule,
+        MatMenuModule,
+        MatToolbarModule,
+        MatCardModule,
+        MatGridListModule,
+        MatTableModule,
+        MatDividerModule,
+        MatDialogModule,
+        MatSnackBarModule,
+        MatFormFieldModule,
+        MatInputModule,
+        FormsModule,
+        MatSelectModule,
+        MatDatepickerModule,
+        MatNativeDateModule,
+        CommonModule
       ],
 
       providers:[
-        TranslateService
+        TranslateService, HttpClient, HttpHandler
       ]
     })
     .compileComponents();

--- a/frontend/src/app/export/export.component.spec.ts
+++ b/frontend/src/app/export/export.component.spec.ts
@@ -1,6 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateService } from '../translate/translate.service';
+import { TranslatePipe } from '../translate/translate.pipe';
 
 import { ExportComponent } from './export.component';
+import { MatIconModule } from '@angular/material';
 
 describe('ExportComponent', () => {
   let component: ExportComponent;
@@ -8,7 +11,13 @@ describe('ExportComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ExportComponent ]
+      declarations: [ ExportComponent, TranslatePipe ],
+      imports: [
+        MatIconModule
+      ],
+      providers: [
+        TranslateService
+      ]
     })
     .compileComponents();
   }));

--- a/frontend/src/app/export/export.component.spec.ts
+++ b/frontend/src/app/export/export.component.spec.ts
@@ -2,8 +2,9 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateService } from '../translate/translate.service';
 import { TranslatePipe } from '../translate/translate.pipe';
 import { ExportComponent } from './export.component';
-import { MatIconModule, MatDatepickerModule, MatNativeDateModule } from '@angular/material';
+import { MatIconModule, MatDatepickerModule, MatNativeDateModule, MatFormFieldModule, MatCheckboxModule, MatSelectModule, MatRadioButton, MatRadioModule, MatProgressSpinnerModule } from '@angular/material';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
 
 describe('ExportComponent', () => {
   let component: ExportComponent;
@@ -16,8 +17,14 @@ describe('ExportComponent', () => {
         MatIconModule,
         MatDatepickerModule,
         MatNativeDateModule,
+        MatFormFieldModule,
+        MatCheckboxModule,
+        MatSelectModule,
+        MatRadioModule,
+        MatProgressSpinnerModule,
         FormsModule,
-        ReactiveFormsModule
+        ReactiveFormsModule,
+        CommonModule
       ],
       providers: [
         TranslateService

--- a/frontend/src/app/export/export.component.spec.ts
+++ b/frontend/src/app/export/export.component.spec.ts
@@ -1,20 +1,20 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ExportSelectorComponent } from './export-selector.component';
+import { ExportComponent } from './export.component';
 
-describe('ExportSelectorComponent', () => {
-  let component: ExportSelectorComponent;
-  let fixture: ComponentFixture<ExportSelectorComponent>;
+describe('ExportComponent', () => {
+  let component: ExportComponent;
+  let fixture: ComponentFixture<ExportComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ExportSelectorComponent ]
+      declarations: [ ExportComponent ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(ExportSelectorComponent);
+    fixture = TestBed.createComponent(ExportComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/frontend/src/app/export/export.component.spec.ts
+++ b/frontend/src/app/export/export.component.spec.ts
@@ -1,9 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateService } from '../translate/translate.service';
 import { TranslatePipe } from '../translate/translate.pipe';
-
 import { ExportComponent } from './export.component';
-import { MatIconModule } from '@angular/material';
+import { MatIconModule, MatDatepickerModule, MatNativeDateModule } from '@angular/material';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 describe('ExportComponent', () => {
   let component: ExportComponent;
@@ -13,7 +13,11 @@ describe('ExportComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ ExportComponent, TranslatePipe ],
       imports: [
-        MatIconModule
+        MatIconModule,
+        MatDatepickerModule,
+        MatNativeDateModule,
+        FormsModule,
+        ReactiveFormsModule
       ],
       providers: [
         TranslateService

--- a/frontend/src/app/export/export.component.spec.ts
+++ b/frontend/src/app/export/export.component.spec.ts
@@ -2,9 +2,11 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateService } from '../translate/translate.service';
 import { TranslatePipe } from '../translate/translate.pipe';
 import { ExportComponent } from './export.component';
-import { MatIconModule, MatDatepickerModule, MatNativeDateModule, MatFormFieldModule, MatCheckboxModule, MatSelectModule, MatRadioButton, MatRadioModule, MatProgressSpinnerModule } from '@angular/material';
+import { MatIconModule, MatDatepickerModule, MatNativeDateModule, MatFormFieldModule, MatCheckboxModule, MatSelectModule, MatRadioButton, MatRadioModule, MatProgressSpinnerModule, MatSnackBarModule } from '@angular/material';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
+import { AcronymPipe } from '../utils/acronym.pipe';
+import { HttpClient, HttpHandler } from '@angular/common/http';
 
 describe('ExportComponent', () => {
   let component: ExportComponent;
@@ -12,7 +14,7 @@ describe('ExportComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ExportComponent, TranslatePipe ],
+      declarations: [ ExportComponent, TranslatePipe, AcronymPipe ],
       imports: [
         MatIconModule,
         MatDatepickerModule,
@@ -21,13 +23,14 @@ describe('ExportComponent', () => {
         MatCheckboxModule,
         MatSelectModule,
         MatRadioModule,
+        MatSnackBarModule,
         MatProgressSpinnerModule,
         FormsModule,
         ReactiveFormsModule,
         CommonModule
       ],
       providers: [
-        TranslateService
+        TranslateService, HttpClient, HttpHandler
       ]
     })
     .compileComponents();

--- a/frontend/src/app/home/home.component.spec.ts
+++ b/frontend/src/app/home/home.component.spec.ts
@@ -1,6 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateService } from '../translate/translate.service';
+import { TranslatePipe } from '../translate/translate.pipe';
 
 import { HomeComponent } from './home.component';
+import { MatIconModule } from '@angular/material';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -8,7 +11,13 @@ describe('HomeComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HomeComponent ]
+      declarations: [ HomeComponent, TranslatePipe ],
+      imports: [
+        MatIconModule
+      ],
+      providers:[
+        TranslateService
+      ]
     })
     .compileComponents();
   }));

--- a/frontend/src/app/home/home.component.spec.ts
+++ b/frontend/src/app/home/home.component.spec.ts
@@ -1,9 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateService } from '../translate/translate.service';
 import { TranslatePipe } from '../translate/translate.pipe';
-
+import { HttpHandler, HttpClient } from '@angular/common/http';
 import { HomeComponent } from './home.component';
-import { MatIconModule } from '@angular/material';
+import { MatIconModule, MatMenuModule, MatToolbarModule, MatCardModule, MatGridListModule, MatTableModule, MatDividerModule, MatDialogModule, MatSnackBarModule } from '@angular/material';
+
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -13,10 +14,18 @@ describe('HomeComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ HomeComponent, TranslatePipe ],
       imports: [
-        MatIconModule
+        MatIconModule,
+        MatMenuModule,
+        MatToolbarModule,
+        MatCardModule,
+        MatGridListModule,
+        MatTableModule,
+        MatDividerModule,
+        MatDialogModule,
+        MatSnackBarModule
       ],
       providers:[
-        TranslateService
+        TranslateService, HttpClient, HttpHandler
       ]
     })
     .compileComponents();

--- a/frontend/src/app/notfound/notfound.component.spec.ts
+++ b/frontend/src/app/notfound/notfound.component.spec.ts
@@ -1,6 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateService } from '../translate/translate.service';
+import { TranslatePipe } from '../translate/translate.pipe';
 
 import { NotfoundComponent } from './notfound.component';
+import { MatIconModule } from '@angular/material';
 
 describe('NotfoundComponent', () => {
   let component: NotfoundComponent;
@@ -8,7 +11,13 @@ describe('NotfoundComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ NotfoundComponent ]
+      declarations: [ NotfoundComponent, TranslatePipe ],
+      imports: [
+        MatIconModule
+      ],
+      providers: [
+        TranslateService
+      ]
     })
     .compileComponents();
   }));

--- a/frontend/src/app/translate/translate.pipe.spec.ts
+++ b/frontend/src/app/translate/translate.pipe.spec.ts
@@ -1,8 +1,9 @@
 import { TranslatePipe } from './translate.pipe';
+import { TranslateService } from './translate.service';
 
 describe('TranslatePipe', () => {
   it('create an instance', () => {
-    const pipe = new TranslatePipe();
+    const pipe = new TranslatePipe(new TranslateService());
     expect(pipe).toBeTruthy();
   });
 });

--- a/frontend/src/app/utils/acronym.pipe.spec.ts
+++ b/frontend/src/app/utils/acronym.pipe.spec.ts
@@ -1,8 +1,9 @@
 import { AcronymPipe } from './acronym.pipe';
+import { TranslateService } from '../translate/translate.service';
 
 describe('AcronymPipe', () => {
   it('create an instance', () => {
-    const pipe = new AcronymPipe();
+    const pipe = new AcronymPipe(new TranslateService());
     expect(pipe).toBeTruthy();
   });
 });


### PR DESCRIPTION
Solved the problem that made it unable to use ng test because mistakes on component declarations, some component's names were changed without using the command line and thus the jasmine and karma framework didn't find them.
Added the necessary imports in each component spec file to enable the component testing, and also now more tests can be added. 
Deleted default tests that weren't useful anymore.
Changed default apiUrl, that must be changed back to aquapp.utb.edu.co from localhost.
